### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -147,7 +147,7 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 
 Create an issue on GitHub, please include the following (if one of them is not applicable to the issue then it's not needed):
 - The steps to reproduce the bug
-- Logs file app.log
+- Logs file ssm_manager.log
 - The version of software
 - Your OS & Browser including server OS
 - What you were expecting to see

--- a/ssm_manager/app.py
+++ b/ssm_manager/app.py
@@ -76,8 +76,8 @@ def get_regions():
             regions = aws_manager.get_regions()
         return jsonify(regions)
     except Exception as e:  # pylint: disable=broad-except
-        logger.error(f"Failed to load AWS regions: {str(e)}")
-        return jsonify({"error": str(e)}), 500
+        logger.error(f"Failed to load AWS regions: {str(e)}", exc_info=True)
+        return jsonify({"error": "Failed to load regions"}), 500
 
 
 @app.route('/api/connect', methods=['POST'])
@@ -102,8 +102,8 @@ def connect():
             'account_id': aws_manager.account_id
         })
     except Exception as e:  # pylint: disable=broad-except
-        logger.error(f"Connection error: {str(e)}")
-        return jsonify({'error': str(e)}), 500
+        logger.error(f"Connection error: {str(e)}", exc_info=True)
+        return jsonify({'error': 'Connection error'}), 500
 
 
 @app.route('/api/instances')


### PR DESCRIPTION
Potential fix for [https://github.com/napalm255/ssm-manager/security/code-scanning/3](https://github.com/napalm255/ssm-manager/security/code-scanning/3)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling in the `/api/regions` and `/api/connect` endpoints.

1. Modify the exception handling in the `/api/regions` endpoint to log the detailed error message and return a generic error message.
2. Modify the exception handling in the `/api/connect` endpoint to log the detailed error message and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
